### PR TITLE
Track tremor-language-server main for CI

### DIFF
--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         command: install
         # TODO: move to --tag v0.11.5 once released
-        args: --git https://github.com/tremor-rs/tremor-language-server.git --branch ensure-crate-download
+        args: --git https://github.com/tremor-rs/tremor-language-server.git --branch main
 
     # Install node modules
     - name: Dependencies


### PR DESCRIPTION
I left it at a branch of my PR where it was successfully building, now that it is merged, we track main until the next release.